### PR TITLE
[BE/feat/26] 캡슐 조회 Get 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ db.sqlite3-journal
 media
 venv
 .idea
+migrations/

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,19 +5,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="a274433b-f04f-4270-8662-5c40252cefdb" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/.idea/MemoryCapsule.iml" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/.idea/inspectionProfiles/Project_Default.xml" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/.idea/inspectionProfiles/profiles_settings.xml" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/.idea/misc.xml" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/.idea/vcs.xml" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/backend/django_back/capsules/migrations/0004_remove_story_capsule_id_remove_story_creator_id_and_more.py" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/backend/django_back/capsules/migrations/0005_alter_capsule_limit_count.py" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/backend/django_back/capsules/migrations/0006_alter_capsule_due_date.py" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/backend/django_back/capsules/migrations/0007_alter_capsule_due_date_alter_capsule_limit_count.py" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/backend/django_back/capsules/serializers.py" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/backend/django_back/users/migrations/0005_alter_user_password.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.gitignore" beforeDir="false" afterPath="$PROJECT_DIR$/.gitignore" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/django_back/capsules/serializers.py" beforeDir="false" afterPath="$PROJECT_DIR$/backend/django_back/capsules/serializers.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/backend/django_back/capsules/views.py" beforeDir="false" afterPath="$PROJECT_DIR$/backend/django_back/capsules/views.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="a274433b-f04f-4270-8662-5c40252cefdb" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.gitignore" beforeDir="false" afterPath="$PROJECT_DIR$/.gitignore" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/backend/django_back/capsules/serializers.py" beforeDir="false" afterPath="$PROJECT_DIR$/backend/django_back/capsules/serializers.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/backend/django_back/capsules/views.py" beforeDir="false" afterPath="$PROJECT_DIR$/backend/django_back/capsules/views.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />

--- a/backend/django_back/capsules/serializers.py
+++ b/backend/django_back/capsules/serializers.py
@@ -4,4 +4,4 @@ from .models import Capsule
 class CapsuleSerializer(serializers.ModelSerializer):
     class Meta:
         model = Capsule
-        fields = ('user_id', 'theme_id', 'capsule_name', 'due_date', 'limit_count')
+        fields = ('user_id', 'theme_id', 'capsule_name', 'due_date', 'limit_count', 'created_at')

--- a/backend/django_back/capsules/views.py
+++ b/backend/django_back/capsules/views.py
@@ -1,3 +1,4 @@
+
 import json
 from datetime import datetime
 
@@ -32,10 +33,21 @@ def capsule_func(request) -> json:
 
 
 def capsule_GET(request) -> (json, int):
-    is_open: bool = bool(request.GET.get('is_open', False))
-    count: int = int(request.GET.get('count', 1))
-    my_capsules = Capsule.objects.filter(user_id=1).order_by('due_date')
-    capsules = Capsule.objects.exclude(user_id=1).order_by('due_date')
+    is_open: bool = json.loads((request.GET.get('is_open', 'False').lower()))
+    count: int = int(request.GET.get('count', -1))
+    user_id: int = int(request.GET.get('user_id', 1))
+
+    # due_date 가 현재 날짜보다 작은 경우는 open 되어 있는 캡슐이므로, __lt를 통해 open 되어 있는 캡슐을 가져왔다
+    # 일반 캡슐의 경우 exclude를 사용하여, __lt의 반대인 __gte를 사용해준다
+    if is_open == False:
+        my_capsules = Capsule.objects.filter(user_id=user_id, due_date__lt=datetime.now()).order_by('due_date')[:count]
+        capsules = Capsule.objects.exclude(user_id=user_id).filter(due_date__lt=datetime.now()).order_by('due_date')[:count]
+    # due_date 가 현재 날짜보다 크거나 같은 경우는 close 되어 있는 캡슐이므로, __gte를 통해 closed 되어 있는 캡슐을 가져온다
+    # 일반 캡슐의 경우 exclude를 사용하여, __gte의 반대인 __lt를 사용해준다
+    else:
+        my_capsules = Capsule.objects.filter(user_id=user_id, due_date__gte=datetime.now()).order_by('due_date')[:count]
+        capsules = Capsule.objects.exclude(user_id=user_id).filter(due_date__gte=datetime.now()).order_by('due_date')[:count]
+
     my_capsules_list = []
     capsules_list = []
 
@@ -94,6 +106,7 @@ def capsule_POST(request) -> (json, int):
             'due_date': serializer.data['due_date'],
             'limit_count': serializer.data['limit_count'],
             'capsule_img_url': capsule_img_url,
+            'created_at': serializer.data['created_at']
         }
     else:
         status_code = 400

--- a/backend/django_back/capsules/views.py
+++ b/backend/django_back/capsules/views.py
@@ -37,16 +37,14 @@ def capsule_GET(request) -> (json, int):
     count: int = int(request.GET.get('count', -1))
     user_id: int = int(request.GET.get('user_id', 1))
 
-    # due_date 가 현재 날짜보다 작은 경우는 open 되어 있는 캡슐이므로, __lt를 통해 open 되어 있는 캡슐을 가져왔다
-    # 일반 캡슐의 경우 exclude를 사용하여, __lt의 반대인 __gte를 사용해준다
-    if is_open == False:
-        my_capsules = Capsule.objects.filter(user_id=user_id, due_date__lt=datetime.now()).order_by('due_date')[:count]
-        capsules = Capsule.objects.exclude(user_id=user_id).filter(due_date__lt=datetime.now()).order_by('due_date')[:count]
-    # due_date 가 현재 날짜보다 크거나 같은 경우는 close 되어 있는 캡슐이므로, __gte를 통해 closed 되어 있는 캡슐을 가져온다
-    # 일반 캡슐의 경우 exclude를 사용하여, __gte의 반대인 __lt를 사용해준다
+    # due_date 가 현재 날짜보다 큰 경우는 open 되어 있는 캡슐이므로, __lt를 통해 open 되어 있는 캡슐을 가져왔다
+    if is_open:
+        my_capsules = Capsule.objects.filter(user_id=user_id, due_date__gt=datetime.now()).order_by('due_date')[:count]
+        capsules = Capsule.objects.exclude(user_id=user_id).filter(due_date__gt=datetime.now()).order_by('due_date')[:count]
+    # due_date 가 현재 날짜보다 작거나 같은 경우는 close 되어 있는 캡슐이므로, __gte를 통해 closed 되어 있는 캡슐을 가져온다
     else:
-        my_capsules = Capsule.objects.filter(user_id=user_id, due_date__gte=datetime.now()).order_by('due_date')[:count]
-        capsules = Capsule.objects.exclude(user_id=user_id).filter(due_date__gte=datetime.now()).order_by('due_date')[:count]
+        my_capsules = Capsule.objects.filter(user_id=user_id, due_date__lte=datetime.now()).order_by('due_date')[:count]
+        capsules = Capsule.objects.exclude(user_id=user_id).filter(due_date__lte=datetime.now()).order_by('due_date')[:count]
 
     my_capsules_list = []
     capsules_list = []


### PR DESCRIPTION
## 🛠️ 변경사항
캡슐 조회 Get 기능 구현

## ☝️ 검토사항
Post : http://0.0.0.0:8080/api/v1/capsules/     
user_id:1
theme_id:1
capsule_name:1
due_date:2021-05-18 16:50:43
limit_count:30

file_name : 파일 선택
하여 데이터를 입력하고,

user_id:1
due_date:2022-05-18 16:50:43

user_id:2
due_date:2021-05-18 16:50:43

user_id:2
due_date:2022-05-18 16:50:43

user_id:1
due_date:2024-05-18 16:50:43

user_id:2
due_date:2024-05-18 16:50:43

로 데이터를 넣고,

Get : http://0.0.0.0:8080/api/v1/capsules/
count:5
is_open:false
user_id:1
로 입력 하여,

user_capsule에 
user_id:1 인 데이터만 들어오는지 체크

is_open=true 일때, 현재 날짜보다 due_date가 큰 경우만 들어오는지 체크
(due_date가 클 때가 열린상태이다!! 주의!!)

is_open_false 일때, 현재 날짜보다 due_date가 작은 경우만 들어오는지 체크

count 값을 조절하여, count 개수에 맞게 데이터 개수가 넘어오는지 체크

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
