### PR TITLE
[feat]  flower 추가 및 capsule 삭제 시 schedule revoke 구현

### DIFF
--- a/backend/django_back/capsules/models.py
+++ b/backend/django_back/capsules/models.py
@@ -18,6 +18,7 @@ class Capsule(BaseModel):
     due_date = models.DateTimeField()
     limit_count = models.IntegerField(null=True, validators=[MinValueValidator(1), MaxValueValidator(30)])
     capsule_img_url = models.CharField(max_length=255)
+    task_id = models.CharField(max_length=36)
 
     class Meta:
         db_table = 'capsule'

--- a/backend/django_back/capsules/utils.py
+++ b/backend/django_back/capsules/utils.py
@@ -106,8 +106,8 @@ def capsule_POST(request) -> (json, int):
     due_date_str = request.POST.get('due_date')
     due_date = datetime.strptime(due_date_str, '%Y-%m-%d %H:%M:%S')
 
-    # if timezone.now().date() >= due_date.date():
-    #     return {'code': 400, 'message': '개봉 날짜가 현재 날짜와 같거나 빠릅니다.'}, 400
+    if timezone.now().date() >= due_date.date():
+        return {'code': 400, 'message': '개봉 날짜가 현재 날짜와 같거나 빠릅니다.'}, 400
 
     val: json
     status_code: int

--- a/backend/django_back/capsules/utils.py
+++ b/backend/django_back/capsules/utils.py
@@ -102,6 +102,13 @@ def capsule_POST(request) -> (json, int):
     if 'img_file' not in request.FILES:
         return {'code': 400, 'message': '파일이 제공되지 않았습니다.'}, 400
 
+    due_date_str = request.POST.get('due_date')
+    due_date = datetime.strptime(due_date_str, '%Y-%m-%d %H:%M:%S')
+
+    # Compare the due_date with the current date
+    if timezone.now().date() >= due_date.date():
+        return {'code': 400, 'message': '개봉 날짜가 현재 날짜와 같거나 빠릅니다.'}, 400
+
     val: json
     status_code: int
 

--- a/backend/django_back/capsules/utils.py
+++ b/backend/django_back/capsules/utils.py
@@ -18,7 +18,7 @@ from bcrypt import checkpw
 import bcrypt
 
 from .serializers import CapsuleSerializer
-from celery import current_app
+from django_back.celery import revoke_task
 
 from django_back.tasks import schedule_video_creation
 
@@ -106,9 +106,8 @@ def capsule_POST(request) -> (json, int):
     due_date_str = request.POST.get('due_date')
     due_date = datetime.strptime(due_date_str, '%Y-%m-%d %H:%M:%S')
 
-    # Compare the due_date with the current date
-    if timezone.now().date() >= due_date.date():
-        return {'code': 400, 'message': '개봉 날짜가 현재 날짜와 같거나 빠릅니다.'}, 400
+    # if timezone.now().date() >= due_date.date():
+    #     return {'code': 400, 'message': '개봉 날짜가 현재 날짜와 같거나 빠릅니다.'}, 400
 
     val: json
     status_code: int
@@ -273,7 +272,7 @@ def capsule_url_parm_DELETE(request, capsule_id) -> (json, int):
         capsule.deleted_at = timezone.now()
         capsule.save()
 
-        current_app.control.revoke(task_id=capsule.task_id, terminate=True)
+        revoke_task(capsule.task_id)
 
         return {'code': 200, 'message': '캡슐 삭제 완료', 'deleted_at': capsule.deleted_at,
                 'time': timezone.now().strftime('%Y-%m-%d %H:%M:%S')}, 200

--- a/backend/django_back/django_back/celery.py
+++ b/backend/django_back/django_back/celery.py
@@ -4,7 +4,10 @@ from django.conf import settings
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'django_back.settings')
 
-app = Celery('backend', broker='amqp://rabbitmq:5672')
+app = Celery('backend', broker='amqp://guest:guest@rabbitmq:5672/')
 app.config_from_object('django.conf:settings', namespace='CELERY')
 app.autodiscover_tasks()
-current_app = app
+
+
+def revoke_task(task_id):
+    app.control.revoke(task_id, terminate=True)

--- a/backend/django_back/django_back/celery.py
+++ b/backend/django_back/django_back/celery.py
@@ -7,3 +7,4 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'django_back.settings')
 app = Celery('backend', broker='amqp://rabbitmq:5672')
 app.config_from_object('django.conf:settings', namespace='CELERY')
 app.autodiscover_tasks()
+current_app = app

--- a/backend/django_back/django_back/settings.py
+++ b/backend/django_back/django_back/settings.py
@@ -56,6 +56,7 @@ INSTALLED_APPS = [
     'django_celery_beat',
     'django_celery_results',
     'django_prometheus',
+    'flower',
 ]
 
 MIDDLEWARE = [
@@ -126,7 +127,6 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-CELERY_RESULT_BACKEND = 'redis://redis:6379/0'
 
 
 GRAFANA = {
@@ -176,12 +176,19 @@ DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
-CELERY_BROKER_URL = 'amqp://rabbitmq:5672'
-CELERY_ACCEPT_CONTENT = ['pickle', 'json']
-CELERY_TASK_SERIALIZER = 'pickle'
+CELERY_BROKER_URL = 'amqp://guest:guest@rabbitmq:5672/'
+CELERY_ACCEPT_CONTENT = ['application/json']
+CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
 CELERY_TIMEZONE = 'Asia/Seoul'
+# Celery task를 종료 가능하게 해주는 세팅 (굉장히 중요)
+CELERY_TASK_REVOKE = True
+CELERY_RESULT_BACKEND = 'redis://redis:6379/0'
+
 DATA_UPLOAD_MAX_MEMORY_SIZE = int(1e10)
+
+CELERY_FLOWER_USER = 'root'  # Flower 웹 인터페이스 사용자 이름
+CELERY_FLOWER_PASSWORD = 'root'  # Flower 웹 인터페이스 비밀번호
 
 CACHES = {
     'default': {

--- a/backend/django_back/django_back/tasks.py
+++ b/backend/django_back/django_back/tasks.py
@@ -18,4 +18,6 @@ def schedule_video_creation(capsule_id, due_date):
     utc_datetime = due_date.astimezone(pytz.utc)
 
     # 작업 실행
-    default_video_maker.apply_async(args=[capsule_id, 1], eta=utc_datetime)
+    task = default_video_maker.apply_async(args=[capsule_id, 1], eta=utc_datetime)
+
+    return task.id

--- a/backend/django_back/requirements.txt
+++ b/backend/django_back/requirements.txt
@@ -59,3 +59,4 @@ uritemplate==4.1.1
 urllib3==1.26.16
 vine==5.0.0
 wcwidth==0.2.6
+flower

--- a/backend/django_back/videos/utils.py
+++ b/backend/django_back/videos/utils.py
@@ -17,7 +17,7 @@ import logging
 from api.message_api import send_normal_message
 
 
-def make_video(capsule, video_number, image_urls, music_url):
+def make_video(capsule_id, video_number, image_urls, music_url):
   
     s3_client = boto3.client('s3')
     s3_resource = boto3.resource('s3')
@@ -126,8 +126,6 @@ def random_video_url_maker(capsule, stories):
     return video_image_url_list
 
 
-
-
 @shared_task
 def default_video_maker(capsule_id, music_id):
     capsule = Capsule.objects.get(capsule_id=capsule_id, deleted_at__isnull=True)
@@ -154,6 +152,7 @@ def default_video_maker(capsule_id, music_id):
     # 일반 메세지 전송
     user_capsules = UserCapsule.objects.filter(capsule_id=capsule_id, deleted_at__isnull=True)
     user_phone_number_list = [user_capsule.user.phone_number for user_capsule in user_capsules]
+    logger.info(f'{user_phone_number_list}')
     title = f'드디어 {capsule.capsule_name}이 열렸어요!!'
     text = f'드디어 {capsule.capsule_name}이 열렸어요!! 어서 확인하러 가봐요!! 확인하러 가기: 사이트 주소'
     send_normal_message(user_phone_number_list, title, text)
@@ -166,4 +165,4 @@ def default_video_maker(capsule_id, music_id):
 def user_choice_video_maker(capsule, music, user_choice_list):
     video_count = Video.objects.filter(capsule=capsule.capsule_id).count() + 1
     music_url = music.music_url
-    return make_video(capsule, video_count, user_choice_list, music_url)
+    return make_video(capsule.capsule_id, video_count, user_choice_list, music_url)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,8 +44,6 @@ services:
                python manage.py migrate &&
                python manage.py makemigrations stories &&
                python manage.py migrate &&
-
-
                python manage.py runserver 0.0.0.0:8080"
 
     ports:
@@ -70,6 +68,11 @@ services:
       - "15672"
     volumes:
       - "./rabbitmq/enabled_plugins:/etc/rabbitmq/enabled_plugins"
+    healthcheck:
+      test: [ "CMD", "rabbitmqctl", "status" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   celery_worker:
     container_name: celery_worker
@@ -78,12 +81,18 @@ services:
       - ./backend/django_back:/backend
     ports: [ ]
     depends_on:
-      - rabbitmq
+      rabbitmq:
+        condition: service_healthy
     environment:
       - C_FORCE_ROOT=true
       - TZ=Asia/Seoul
     command: sh -c "python wait_mysql.py &&
       celery -A django_back worker --loglevel=info"
+    healthcheck:
+      test: [ "CMD", "celery", "inspect", "ping" ]
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
   celery_beat:
    container_name: celery_beat
@@ -92,8 +101,8 @@ services:
      - ./backend/django_back:/backend
    ports: [ ]
    depends_on:
-     - rabbitmq
-     - celery_worker
+     rabbitmq:
+       condition: service_healthy
    environment:
      - C_FORCE_ROOT=true
      - TZ=Asia/Seoul
@@ -101,14 +110,12 @@ services:
      celery -A django_back beat --loglevel=info"
 
   redis_container:
-    # 사용할 이미지
     image: redis:latest
-    # 컨테이너명
     container_name: redis
-    # 접근 포트 설정(컨테이너 외부:컨테이너 내부)
+    environment:
+      - TZ=Asia/Seoul
     ports:
       - "6379:6379"
-    # 스토리지 마운트(볼륨) 설정
     volumes:
       - ./redis/data:/data
       - ./redis/conf/redis.conf:/usr/local/conf/redis.conf
@@ -119,7 +126,6 @@ services:
     labels:
       - "name=redis"
       - "mode=standalone"
-    # 컨테이너 종료시 재시작 여부 설정
     restart: always
     command: redis-server /usr/local/conf/redis.conf
     
@@ -131,8 +137,25 @@ services:
 #      - ./monitoring/prometheus:/etc/prometheus
 #    command:
 #      - "--config.file=/etc/prometheus/prometheus.yml"
-#
-#  grafana: # 그라파나 서비스 추가
+
+  flower:
+    image: mher/flower
+    container_name: flower
+    environment:
+      - CELERY_BROKER_URL=amqp://guest:guest@rabbitmq:5672/
+      - CELERY_RESULT_BACKEND=redis://redis:6379/0
+      - TZ=Asia/Seoul
+    ports:
+      - '5555:5555'
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      celery_worker:
+        condition: service_started
+
+
+
+  #  grafana: # 그라파나 서비스 추가
 #    image: grafana/grafana
 #    ports:
 #      - "3000:3000"


### PR DESCRIPTION
## 🛠️ 변경사항
- flower 추가 및 capsule 삭제 시 schedule revoke 구현

## ☝️ 점검사항
- capsule을 생성하기 전, /capsules/utils.py의 109번째 줄의
timezone를 주석처리 하고,
test data를 입력한 후에, due_date를 지정한다.
0.0.0.0:5555로 flower에 접속한 후,
schedule이 되었는지 확인하고, 해당 캡슐을 delete 한 후,
due_date가 된 타이밍에 flower 에서 해당 task가 revoke 상태인지를 체크한다 

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
